### PR TITLE
Refresh sessions

### DIFF
--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -226,4 +226,5 @@ COMPRESS_CSS_FILTERS = [
     'compressor.filters.cssmin.rCSSMinFilter',
 ]
 
+SESSION_SAVE_EVERY_REQUEST = True
 HUDDLE_BOARD_REFRESH_TIMER = 15

--- a/pompom/apps/huddle_board/admin.py
+++ b/pompom/apps/huddle_board/admin.py
@@ -16,6 +16,14 @@ from pompom.apps.huddle_board.forms import CardForm, DeckForm
 from .models import Card, CardSection, Observation, Answer, Board, Deck, \
     CardNote, SafetyMessage, SiteConfiguration
 
+from django.contrib.sessions.models import Session
+
+@admin.register(Session)
+class SessionAdmin(admin.ModelAdmin):
+    def _session_data(self, obj):
+        return obj.get_decoded()
+    list_display = ['session_key', '_session_data', 'expire_date']
+
 
 class DateFilter(SimpleListFilter):
     title = 'date'

--- a/pompom/apps/huddle_board/models.py
+++ b/pompom/apps/huddle_board/models.py
@@ -210,3 +210,4 @@ class SiteConfiguration(SingletonModel):
     def get_board_passwords(cls):
         config = cls.get_solo()
         return {password.strip() for password in config.board_passwords.split(',') if password.strip()}
+


### PR DESCRIPTION
Kevin fixed the session id cookie so its expiration is reset with each refresh. The prevents the cookie from expiring and the user from needing to re-log in every two weeks.